### PR TITLE
Increase accessibility in response to new changes from aedb37d

### DIFF
--- a/src/commands/manualDeletion.js
+++ b/src/commands/manualDeletion.js
@@ -9,7 +9,7 @@ export default {
     .addUserOption((option) =>
       option
         .setName('user')
-        .setDescription('The user to earase from the DB')
+        .setDescription('The user to erase from the DB')
         .setRequired(true),
     ),
     async execute(interaction) {


### PR DESCRIPTION
aedb37d introduced a new verb, "earase", which may be foreign to some users. Using the more commonplace term, "erase", can increase accessibility and aid comprehension of these otherwise unknown ideas.